### PR TITLE
fix(unsupported): return "" instead of nil from string-returning fallbacks (#2)

### DIFF
--- a/explorer_unsupported.go
+++ b/explorer_unsupported.go
@@ -12,7 +12,7 @@ func newExplorer(_ RunHandler) *explorer {
 func (e *Explorer) setView(_ uintptr) {}
 
 func (e *Explorer) importFile(_ ...string) (string, error) {
-	return nil, ErrNotAvailable
+	return "", ErrNotAvailable
 }
 
 func (e *Explorer) importFiles(_ ...string) ([]string, error) {
@@ -20,5 +20,5 @@ func (e *Explorer) importFiles(_ ...string) ([]string, error) {
 }
 
 func (e *Explorer) exportFile(_ string) (string, error) {
-	return nil, ErrNotAvailable
+	return "", ErrNotAvailable
 }


### PR DESCRIPTION
Fixes #2. `explorer_unsupported.go` had two methods returning `nil` where the signature is `(string, error)`:

- `importFile(_ ...string) (string, error)` line 14-16
- `exportFile(_ string) (string, error)` line 22-24

`nil` is not assignable to `string`, so this file fails to compile when the build constraint matches (any non-windows/darwin/linux GOOS, e.g. freebsd/netbsd/openbsd/dragonfly). `importFiles` is unchanged because its signature is `([]string, error)` and `nil` is valid for slices.

Two-character fix per method: `nil` → `""`.

## Test plan

- [x] `gofmt -d explorer_unsupported.go` clean
- [x] Manual: signatures match the OS-specific implementations under the same build constraint family